### PR TITLE
Initialize pnpm workspace skeleton

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+**/dist

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,25 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    node: true,
+    es2020: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  rules: {
+    'prettier/prettier': 'error',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error'],
+    'no-console': 'warn',
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+**/dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 80
+}

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MMORPG Client</title>
+</head>
+<body>
+  <div id="game"></div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "client",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "phaser": "^3.90.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^4.5.0",
+    "vite-tsconfig-paths": "^4.0.0"
+  }
+}

--- a/client/src/BootScene.ts
+++ b/client/src/BootScene.ts
@@ -1,0 +1,15 @@
+import Phaser from 'phaser';
+
+export default class BootScene extends Phaser.Scene {
+  constructor() {
+    super('boot');
+  }
+
+  preload() {
+    // preload assets here
+  }
+
+  create() {
+    this.scene.start('game');
+  }
+}

--- a/client/src/GameScene.ts
+++ b/client/src/GameScene.ts
@@ -1,0 +1,30 @@
+import Phaser from 'phaser';
+
+export default class GameScene extends Phaser.Scene {
+  private square!: Phaser.GameObjects.Rectangle;
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+
+  constructor() {
+    super('game');
+  }
+
+  create() {
+    this.square = this.add.rectangle(400, 300, 50, 50, 0xff0000);
+    this.cursors = this.input.keyboard.createCursorKeys();
+  }
+
+  update() {
+    const speed = 200;
+    if (this.cursors.left?.isDown) {
+      this.square.x -= speed * this.game.loop.delta / 1000;
+    } else if (this.cursors.right?.isDown) {
+      this.square.x += speed * this.game.loop.delta / 1000;
+    }
+
+    if (this.cursors.up?.isDown) {
+      this.square.y -= speed * this.game.loop.delta / 1000;
+    } else if (this.cursors.down?.isDown) {
+      this.square.y += speed * this.game.loop.delta / 1000;
+    }
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,0 +1,19 @@
+import Phaser from 'phaser';
+import BootScene from './BootScene';
+import GameScene from './GameScene';
+
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  width: 800,
+  height: 600,
+  parent: 'game',
+  scene: [BootScene, GameScene],
+};
+
+new Phaser.Game(config);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+    console.log('HMR');
+  });
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+});

--- a/devops/.github/workflows/ci.yml
+++ b/devops/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:18
+WORKDIR /app
+COPY .. .
+RUN pnpm install --frozen-lockfile
+CMD ["pnpm", "dev"]

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+      - '3000:3000'
+      - '2567:2567'

--- a/devops/package.json
+++ b/devops/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "devops",
+  "version": "1.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mmorpg",
+  "private": true,
+  "packageManager": "pnpm@8.7.0",
+  "scripts": {
+    "dev": "pnpm -r --parallel dev",
+    "lint": "eslint . --ext .ts,.tsx,.js,.jsx"
+  },
+  "devDependencies": {
+    "eslint": "^8.54.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.0.0"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - client
+  - server
+  - shared
+  - devops

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "colyseus": "^1.0.0",
+    "@colyseus/schema": "^1.0.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,27 @@
+import { Server } from 'colyseus';
+import { createServer } from 'http';
+import express from 'express';
+import { Room, Client } from 'colyseus';
+import { PlayerState } from '../shared/src';
+
+class MyRoom extends Room<PlayerState> {
+  onCreate() {
+    this.setState({ x: 0, y: 0 });
+  }
+
+  onJoin(client: Client) {
+    console.log('Client joined', client.sessionId);
+  }
+
+  onLeave(client: Client) {
+    console.log('Client left', client.sessionId);
+  }
+}
+
+const app = express();
+const gameServer = new Server({ server: createServer(app) });
+
+gameServer.define('room', MyRoom);
+
+gameServer.listen(2567);
+console.log('Colyseus listening on ws://localhost:2567');

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "shared",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,0 +1,11 @@
+export enum Input {
+  Up = 'up',
+  Down = 'down',
+  Left = 'left',
+  Right = 'right',
+}
+
+export interface PlayerState {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
## Summary
- set up pnpm monorepo with client, server, shared, and devops packages
- bootstrap Phaser client with simple moving square
- add Colyseus server and shared types
- add Dockerfile, docker-compose, and GitHub Actions workflow
- configure ESLint and Prettier at repo root

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684b07dd1dcc832fa9557f3cbe274271