### PR TITLE
Add shared protocol constants and schema

### DIFF
--- a/shared/src/Input.ts
+++ b/shared/src/Input.ts
@@ -1,0 +1,7 @@
+export enum Input {
+  UP = 1 << 0,
+  DOWN = 1 << 1,
+  LEFT = 1 << 2,
+  RIGHT = 1 << 3,
+  SHOOT = 1 << 4,
+}

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -1,0 +1,5 @@
+export const TICK_RATE = 30;
+
+export const WORLD_SIZE = { width: 1024, height: 768 } as const;
+
+export const PLAYER_SPEED = 200; // pixels per second

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,9 +1,7 @@
-export enum Input {
-  Up = 'up',
-  Down = 'down',
-  Left = 'left',
-  Right = 'right',
-}
+export { Input } from './Input';
+export { TICK_RATE, WORLD_SIZE, PLAYER_SPEED } from './constants';
+export { Player } from './schema/Player';
+export { WorldState } from './schema/WorldState';
 
 export interface PlayerState {
   x: number;

--- a/shared/src/schema/Player.ts
+++ b/shared/src/schema/Player.ts
@@ -1,0 +1,18 @@
+import { Schema, type } from '@colyseus/schema';
+
+export class Player extends Schema {
+  @type('string')
+  id: string = '';
+
+  @type('number')
+  x: number = 0;
+
+  @type('number')
+  y: number = 0;
+
+  @type('number')
+  hp: number = 100;
+
+  @type('number')
+  rotation: number = 0;
+}

--- a/shared/src/schema/WorldState.ts
+++ b/shared/src/schema/WorldState.ts
@@ -1,0 +1,7 @@
+import { Schema, type, MapSchema } from '@colyseus/schema';
+import { Player } from './Player';
+
+export class WorldState extends Schema {
+  @type({ map: Player })
+  players = new MapSchema<Player>();
+}


### PR DESCRIPTION
## Summary
- define core game constants such as tick rate, world size and player speed
- provide bit masked Input enum
- implement `Player` and `WorldState` schema classes
- re-export new modules from `shared/src/index.ts`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_684b1f89e93c832fb09b6b71f8c8ad60