### PR TITLE
Implement WorldRoom and server entry

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,27 +1,12 @@
-import { Server } from 'colyseus';
-import { createServer } from 'http';
 import express from 'express';
-import { Room, Client } from 'colyseus';
-import { PlayerState } from '../shared/src';
-
-class MyRoom extends Room<PlayerState> {
-  onCreate() {
-    this.setState({ x: 0, y: 0 });
-  }
-
-  onJoin(client: Client) {
-    console.log('Client joined', client.sessionId);
-  }
-
-  onLeave(client: Client) {
-    console.log('Client left', client.sessionId);
-  }
-}
+import { createServer } from 'http';
+import { Server } from 'colyseus';
+import { WorldRoom } from './rooms/WorldRoom';
 
 const app = express();
 const gameServer = new Server({ server: createServer(app) });
 
-gameServer.define('room', MyRoom);
+gameServer.define('world', WorldRoom);
 
 gameServer.listen(2567);
 console.log('Colyseus listening on ws://localhost:2567');

--- a/server/src/rooms/WorldRoom.ts
+++ b/server/src/rooms/WorldRoom.ts
@@ -1,0 +1,61 @@
+import { Room, Client } from 'colyseus';
+import {
+  WorldState,
+  Player,
+  Input,
+  PLAYER_SPEED,
+  TICK_RATE,
+} from '../../../shared/src';
+
+export class WorldRoom extends Room<WorldState> {
+  private inputBuffer: Record<string, Input[]> = {};
+
+  onCreate() {
+    this.setState(new WorldState());
+    this.setSimulationInterval(() => this.update(), 1000 / TICK_RATE);
+
+    this.onMessage('input', (client, message: Input) => {
+      if (!this.inputBuffer[client.sessionId]) {
+        this.inputBuffer[client.sessionId] = [];
+      }
+      this.inputBuffer[client.sessionId].push(message);
+    });
+  }
+
+  onJoin(client: Client) {
+    const player = new Player();
+    player.id = client.sessionId;
+    this.state.players.set(client.sessionId, player);
+    this.inputBuffer[client.sessionId] = [];
+    this.broadcast('playerJoined', { id: player.id });
+  }
+
+  onLeave(client: Client) {
+    this.state.players.delete(client.sessionId);
+    delete this.inputBuffer[client.sessionId];
+    this.broadcast('playerLeft', { id: client.sessionId });
+  }
+
+  private update() {
+    const dt = 1 / TICK_RATE;
+    this.state.players.forEach((player, id) => {
+      const buffer = this.inputBuffer[id];
+      if (!buffer) return;
+      while (buffer.length > 0) {
+        const input = buffer.shift()!;
+        if (input & Input.LEFT) {
+          player.x -= PLAYER_SPEED * dt;
+        }
+        if (input & Input.RIGHT) {
+          player.x += PLAYER_SPEED * dt;
+        }
+        if (input & Input.UP) {
+          player.y -= PLAYER_SPEED * dt;
+        }
+        if (input & Input.DOWN) {
+          player.y += PLAYER_SPEED * dt;
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- implement `WorldRoom` room with fixed tick update
- spawn/remove players on join/leave and process input messages
- set up server entrypoint to run Colyseus with `WorldRoom`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684b20431600832fb0febcf55b1a232b